### PR TITLE
Add and use `@rails/request.js`

### DIFF
--- a/app/javascript/controllers/calculate_distance_and_duration_controller.js
+++ b/app/javascript/controllers/calculate_distance_and_duration_controller.js
@@ -1,27 +1,25 @@
 import { Controller } from "@hotwired/stimulus"
+import { post } from "@rails/request.js"
 
-// Connects to data-controller="calculate-total-distance-and-duration"
+// Connects to data-controller="calculate-distance-and-duration"
 export default class extends Controller {
   connect() {
     console.log("The 'distance and duration calculator' controller is connected");
   }
 
-  calculate() {
-    let locale = window.location.pathname.split('/')[1];
+  async calculate() {
+    const locale = window.location.pathname.split('/')[1]
+    const url = `/${locale}/appointments/calculate_distance_and_duration`
+    const response = await post(url)
 
-    fetch(`/${locale}/appointments/calculate_distance_and_duration`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'X-CSRF-Token': document.querySelector("meta[name='csrf-token']").getAttribute('content')
-      }
-    })
-    .then(response => response.json())
-    .then(data => {
+    if (response.ok) {
+      const data = await response.json
+
       // Update the total distance and duration in your view
       document.querySelector("#driving_distance").textContent = `${data.driving_distance} km`;
       document.querySelector("#driving_duration").textContent = `${data.driving_duration} min`;
-      })
-    .catch(error => console.error('Error:', error));
+    } else {
+      console.error("Couldn't update the driving distance and duration")
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@hotwired/stimulus": "^3.2.1",
     "@hotwired/turbo-rails": "^7.3.0",
     "@popperjs/core": "^2.11.7",
+    "@rails/request.js": "^0.0.9",
     "bootstrap": "^5.2.3",
     "bootstrap-sass": "^3.3.7",
     "esbuild": "^0.17.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -140,6 +140,11 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.0.8.tgz#f44e7517f2d1570f1eabeea457dbeb17ed3a2d12"
   integrity sha512-GjYQv89ZOOfbFw8VMNUOG33GXzyAA/TCVoD+742Ob4svm1XXUkd+w+ewqUXd+7VHQtV35y1/O78AGIPeJDTy/g==
 
+"@rails/request.js@^0.0.9":
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/@rails/request.js/-/request.js-0.0.9.tgz#89e2a575405dc07eb8a9b3d2fe04289e1f057cd0"
+  integrity sha512-VleYUyrA3rwKMvYnz7MI9Ada85Vekjb/WVz7NuGgDO24Y3Zy9FFSpDMQW+ea/tlftD+CdX/W/sUosRA9/HkDOQ==
+
 anymatch@~3.1.2:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.3.tgz#790c58b19ba1720a84205b57c618d5ad8524973e"
@@ -260,11 +265,6 @@ is-number@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
-
-jstz@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/jstz/-/jstz-2.1.1.tgz#fff3373a518fa7cce69299930466f5a2b980389d"
-  integrity sha512-8hfl5RD6P7rEeIbzStBz3h4f+BQHfq/ABtoU6gXKQv5OcZhnmrIpG7e1pYaZ8hS9e0mp+bxUj08fnDUbKctYyA==
 
 normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Hey @a160v 👋🏼 

This pull request refactors your `calculate-distance-and-duration` Stimulus controller to use the [`@rails/request.js`](https://github.com/rails/request.js) library. 

The Request.js library is a thin wrapper around the native `fetch` function, but handles the CSRF token and the JSON format for you out of the box. This allows us the simplify the Stimulus controller a bit. 